### PR TITLE
Rename master->main in fetch scripts and .circleci config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,7 +16,7 @@ workflows:
         cron: "0 6 * * *"
         filters:
           branches:
-            only: master
+            only: main
     jobs:
       - build-test-linux
       - build-test-osx

--- a/fetch-linux.sh
+++ b/fetch-linux.sh
@@ -10,5 +10,5 @@ unzip linux-gcc-64bit-static.zip
 
 # the release only includes C related stuff, so grab the C++ stuff from github raw content
 mkdir -p cpp/include/launchdarkly
-curl -Ls https://raw.githubusercontent.com/launchdarkly/c-client-sdk/master/cpp/api.cpp > cpp/api.cpp
-curl -Ls https://raw.githubusercontent.com/launchdarkly/c-client-sdk/master/cpp/include/launchdarkly/api.hpp > cpp/include/launchdarkly/api.hpp
+curl -Ls https://raw.githubusercontent.com/launchdarkly/c-client-sdk/main/cpp/api.cpp > cpp/api.cpp
+curl -Ls https://raw.githubusercontent.com/launchdarkly/c-client-sdk/main/cpp/include/launchdarkly/api.hpp > cpp/include/launchdarkly/api.hpp

--- a/fetch-mac.command
+++ b/fetch-mac.command
@@ -9,5 +9,5 @@ unzip osx-clang-64bit-static.zip
 
 # the release only includes C related stuff, so grab the C++ stuff from github raw content
 mkdir -p cpp/include/launchdarkly
-curl -Ls https://raw.githubusercontent.com/launchdarkly/c-client-sdk/master/cpp/api.cpp > cpp/api.cpp
-curl -Ls https://raw.githubusercontent.com/launchdarkly/c-client-sdk/master/cpp/include/launchdarkly/api.hpp > cpp/include/launchdarkly/api.hpp
+curl -Ls https://raw.githubusercontent.com/launchdarkly/c-client-sdk/main/cpp/api.cpp > cpp/api.cpp
+curl -Ls https://raw.githubusercontent.com/launchdarkly/c-client-sdk/main/cpp/include/launchdarkly/api.hpp > cpp/include/launchdarkly/api.hpp

--- a/fetch-windows.ps1
+++ b/fetch-windows.ps1
@@ -9,5 +9,5 @@ Expand-Archive -Path windows-vs-64bit-dynamic.zip -DestinationPath .
 cp lib/ldclientapi.dll .
 
 New-Item -ItemType directory -Path "cpp/include/launchdarkly"
-Invoke-WebRequest -Uri "https://raw.githubusercontent.com/launchdarkly/c-client-sdk/master/cpp/api.cpp" -Outfile "cpp/api.cpp"
-Invoke-WebRequest -Uri "https://raw.githubusercontent.com/launchdarkly/c-client-sdk/master/cpp/include/launchdarkly/api.hpp" -Outfile "cpp/include/launchdarkly/api.hpp"
+Invoke-WebRequest -Uri "https://raw.githubusercontent.com/launchdarkly/c-client-sdk/main/cpp/api.cpp" -Outfile "cpp/api.cpp"
+Invoke-WebRequest -Uri "https://raw.githubusercontent.com/launchdarkly/c-client-sdk/main/cpp/include/launchdarkly/api.hpp" -Outfile "cpp/include/launchdarkly/api.hpp"


### PR DESCRIPTION
Must not be merged until:
- [x] Upstream c-server-sdk has been renamed