### PR TITLE
sc 154164/update c c client side sdk hello app readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,4 +13,4 @@ const char *feature_key = "YOUR_FEATURE_KEY";
 3. Build for your platform with `build-linux.sh`, `build-mac.command`, or `build-windows.ps1`.
 4. On the command line, run `./hello`.
 
-You should see the message `"Feature flag '<flag key>' is <true/false> for this user"`.
+You should receive the message `"Feature flag '<flag key>' is <true/false> for this user"`.

--- a/README.md
+++ b/README.md
@@ -1,8 +1,16 @@
 # LaunchDarkly Sample C++ Client-Side Application
-We've built a simple console application that demonstrates how LaunchDarkly's SDK works. Below, you'll find the basic build procedure, but for more comprehensive instructions, you can visit your Quickstart page. Use this as a starting point for integrating the c-client-sdk with your application.
+We've built a simple console application that demonstrates how LaunchDarkly's SDK works. Below, you'll find the basic build procedure, but for more comprehensive instructions, you can visit your [Quickstart page](https://app.launchdarkly.com/quickstart#/) or the [C/C++ SDK reference guide](https://docs.launchdarkly.com/sdk/client-side/c-c--).
 
 ## Build instructions
-1. Copy your Mobile SDK key and feature flag key from your LaunchDarkly dashboard into `hello.cpp`
-2. Download the latest SDK for your platform with `fetch-linux.sh`, `fetch-mac.sh`, or `fetch-windows.ps1`
-3. Build for your platform with `build-linux.sh`, `build-mac.sh`, or `build-windows.ps1`
-4. Run `./hello`
+1. Edit `hello.cpp` and set the value of `mobile_key` to your LaunchDarkly mobile key. If there is an existing boolean feature flag in your LaunchDarkly project that you want to evaluate, set `feature_key` to the flag key.
+
+```
+const char *mobile_key = "YOUR_MOBILE_KEY";
+const char *feature_key = "YOUR_FEATURE_KEY";
+```
+
+2. Download the latest SDK for your platform with `fetch-linux.sh`, `fetch-mac.command`, or `fetch-windows.ps1`.
+3. Build for your platform with `build-linux.sh`, `build-mac.command`, or `build-windows.ps1`.
+4. On the command line, run `./hello`.
+
+You should see the message `"Feature flag '<flag key>' is <true/false> for this user"`.

--- a/hello.cpp
+++ b/hello.cpp
@@ -1,28 +1,44 @@
 #include <launchdarkly/api.hpp>
 
-const char *username = "jeff@example.com";
+// Set mobile_key to your LaunchDarkly mobile key.
+const char *mobile_key = "";
 
-// update me to your own keys
-const char *sdk_key = "YOUR_SDK_KEY";
-const char *feature_key = "YOUR_FEATURE_KEY";
+// Set feature_key to the feature flag you want to evaluate.
+const char *feature_key = "my-boolean-flag";
 
 int main() {
-    LDConfigureGlobalLogger(LD_LOG_INFO, LDBasicLogger);
-
-    auto *config = LDConfigNew(sdk_key);
-    auto *user = LDUserNew(username);
-
-    // wait up to 3 seconds to connect
-    auto *client = LDClientCPP::Init(config, user, 3000);
-
-    auto feature = client->boolVariation(feature_key, false);
-
-    if (feature) {
-        printf("My feature was enabled for %s\n", username);
-    } else {
-        printf("My feature was not enabled for %s\n", username);
+    if (mobile_key && !mobile_key[0]) {
+      printf("*** Please edit hello.cpp to set mobile_key to your LaunchDarkly mobile key first\n\n");
+      return 1;
     }
 
-    // cleanup after ourselves
+    LDConfigureGlobalLogger(LD_LOG_INFO, LDBasicLogger);
+
+    struct LDConfig *config = LDConfigNew(mobile_key);
+
+    // Set up the user properties. This user should appear on your LaunchDarkly users dashboard
+    // soon after you run the demo.
+    struct LDUser *user = LDUserNew("example-user-key");
+    LDUserSetName(user, "Sandy");
+
+    // wait up to 3 seconds to connect
+    LDClientCPP *client = LDClientCPP::Init(config, user, 3000);
+
+    if (client->isInitialized()) {
+        printf("*** SDK successfully initialized!\n\n");
+    } else {
+        printf("*** SDK failed to initialize\n\n");
+        return 1;
+    }
+
+    auto flag_value = client->boolVariation(feature_key, false);
+
+    printf("*** Feature flag '%s' is %s for this user\n\n", feature_key, flag_value ? "true" : "false");
+
+    // Here we ensure that the SDK shuts down cleanly and has a chance to deliver analytics
+    // events to LaunchDarkly before the program exits. If analytics events are not delivered,
+    // the user properties and flag usage statistics will not appear on your dashboard. In a
+    // normal long-running application, the SDK would continue running and events would be
+    // delivered automatically in the background.
     client->close();
 }

--- a/hello.cpp
+++ b/hello.cpp
@@ -1,3 +1,4 @@
+#include <string.h>
 #include <launchdarkly/api.hpp>
 
 // Set mobile_key to your LaunchDarkly mobile key.
@@ -7,7 +8,7 @@ const char *mobile_key = "";
 const char *feature_key = "my-boolean-flag";
 
 int main() {
-    if (mobile_key && !mobile_key[0]) {
+    if (strlen(mobile_key) == 0) {
       printf("*** Please edit hello.cpp to set mobile_key to your LaunchDarkly mobile key first\n\n");
       return 1;
     }


### PR DESCRIPTION
[SC-154164](https://app.shortcut.com/launchdarkly/story/154164/update-c-c-client-side-sdk-hello-app-readme-and-comments-to-standard-design): After receiving some feedback that it'd be helpful if the Hello apps were more standardized,  Docs team is working on updating them to [match the spec](https://launchdarkly.atlassian.net/wiki/spaces/ENG/pages/1499562073/SDK+hello+world). 

I've built and tested locally on OS X.
